### PR TITLE
Lucas/argparse

### DIFF
--- a/src/fl.go
+++ b/src/fl.go
@@ -8,17 +8,97 @@ import (
 	"strings"
 )
 
-func main() {
+/**********************
+ * globals/helpers
+ *********************/
+
+/*
+ * To add a flag:
+ * 1. Update its entry in Usage()
+ * 2. Add it to the string list called 'flags' below and update numFlags
+ * 3. Create a handler function and add it to the switch-case in argParse()
+ */
+// useage definition functions to explain command and its args
+var Usage = func () {
+	fmt.Println("Usage of fl:")
+	fmt.Println("\t-h,--help: show command usage")
+}
+
+// list of allowed flags
+var (
+	flags = []string { 
+		"-h", "--help" ,
+		"-y",
+	}
+)
+
+// number of distinct flags
+const (
+	numFlags = 2	
+) 
+
+/**********************
+ * arg parsing/ handlers
+ *********************/
+
+// handler for when --help or -h are provided
+func flagHandleHelp() {
+	Usage()
+	os.Exit(1)
+}
+
+// handler for when -y is provided
+func flagHandleExecuteCmd() {
+
+}
+
+// parse the user input for potential prompts
+var argParse = func () (prompt string) {
 	// Check if command line arguments are provided
 	if len(os.Args) < 2 {
 		// expecting at least 2 arguments
-		fmt.Println("Usage: fl <prompt>")
+		Usage()
 		os.Exit(1)
 	}
 
+	// Start of the user prompt (after args have been parsed)
+	startPromptIndex := 1
+	// flag to exit for loop if non-flag detected
+	validArg := true
+
+	// check for flags (add 1 bc first index is command path)
+	for i := 1; i < numFlags+1 && validArg; i++ {
+		switch os.Args[i] {
+		case "-h": // help commands (just display useage)
+			fallthrough
+		case "--help":
+			startPromptIndex++
+			flagHandleHelp()
+		case "-y": // execute command automatically
+			startPromptIndex++
+			flagHandleExecuteCmd()
+		default:
+			// skip searching for switches if invalid arg is found (assume it is prompt)
+			validArg = false
+			break
+		}
+	}
+
+	prompt = strings.Join(os.Args[startPromptIndex:], " ")
+	if prompt == "" {
+		fmt.Println("Prompt cannot be empty\n")
+		Usage()
+		os.Exit(1)
+	}
+
+	return (prompt)
+}
+
+func main() {
+	// parse arguments and recieve prompt
+	prompt := argParse()
 	// Concatenate all arguments to form the payload
 	apiUrl := "https://flow.pstmn-beta.io/api/4e5b4cfcdec54831a31d9f38aaf1a938"
-	prompt := strings.Join(os.Args[1:], " ")
 
 	// Make the API call
 	response, err := http.Post(apiUrl, "application/json", strings.NewReader(fmt.Sprintf(`{"prompt": "%s"}`, prompt)))


### PR DESCRIPTION
Avoided use of "flags" library for argparsing because it appears to be limited.

This way, no quotations or flags are necessary for the prompt. Flags are recognized if entered before the prompt. 

More features are in a separate branch. Feel free to leave comments.