### PR TITLE
Feature language

### DIFF
--- a/src/fl.go
+++ b/src/fl.go
@@ -38,7 +38,7 @@ func noTui(Flags helpers.FlagStruct, Config io.Config) {
 
 	// Make the API call
 	helpers.Print(Flags.Verbose, "Sending prompt...")
-	res, err := web.PromptAI(apiUrl, Flags.Prompt)
+	res, err := web.PromptAI(apiUrl, Flags.Prompt, Flags.Language)
 	if err != nil {
 		fmt.Printf("Failed to call Flows API: %s\n", err)
 		os.Exit(1)

--- a/src/fl.go
+++ b/src/fl.go
@@ -97,9 +97,6 @@ func noTui(Flags helpers.FlagStruct, Config io.Config) {
 
 func main() {
 
-	// initialize flags struct
-	Flags := helpers.ConstructFlags()
-
 	// get config data
 	Config, err := io.ReadConf()
 	if err != nil {
@@ -125,6 +122,8 @@ func main() {
 		os.Exit(0)
 	}
 
+	// initialize flags struct
+	Flags := helpers.ConstructFlags(Config)
 	// parse arguments and recieve prompt
 	err = helpers.ArgParse(os.Args, &Flags)
 

--- a/src/fl.go
+++ b/src/fl.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// url of the Flow endpoint
-	apiUrl = "https://flow.pstmn-beta.io/api/4e5b4cfcdec54831a31d9f38aaf1a938"
+	apiUrl = "https://flow.pstmn-beta.io/api/38a029541f794a65afb284a7f4e7d3b3"
 )
 
 func init() {

--- a/src/helpers/argparse.go
+++ b/src/helpers/argparse.go
@@ -22,7 +22,7 @@ type FlagStruct struct {
 	Len                                    int
 }
 
-func ConstructFlags() (Flags FlagStruct) {
+func ConstructFlags(Config io.Config) (Flags FlagStruct) {
 	return FlagStruct{
 		Verbose:    false,
 		Help:       false,
@@ -31,7 +31,7 @@ func ConstructFlags() (Flags FlagStruct) {
 		Output:     false,
 		Outfile:    "",
 		Prompt:     "",
-		Language:   "Bash/Unix",
+		Language:   Config.Language,
 		Len:        6,
 	}
 }
@@ -53,6 +53,7 @@ Usage: fl [-hnvt] [-o filename] [-l language] prompt...
 Config: fl conf <config param>
 
  --autoexecute=BOOL     enable autoexecution
+ --language=STRING      change the DEFAULT language/environment to generate a command for
 
 `)
 }
@@ -104,6 +105,12 @@ func confHandlerAutoexec(Config *io.Config, arg string) {
 	}
 }
 
+func confHandlerLanguage(Config *io.Config, arg string) {
+	// rewrite autoexec with right side of '='
+	value := strings.Split(arg, "=")[1]
+	Config.Language = strings.ToLower(value)
+}
+
 /**********************
  * Other parse helpers
  *********************/
@@ -118,6 +125,7 @@ func IsEmpty(str string) bool {
 
 var (
 	regex_autoexecute = regexp.MustCompile("--autoexecute=")
+	regex_language    = regexp.MustCompile("--language=")
 )
 
 // check if this is a config command - follow format 'fl config <CONFIGCMD>'
@@ -125,6 +133,8 @@ func ConfParse(args []string, Config *io.Config) (confCmd bool, err error) {
 	if args[1] == "conf" {
 		if regex_autoexecute.MatchString(args[2]) {
 			confHandlerAutoexec(Config, args[2])
+		} else if regex_language.MatchString(args[2]) {
+			confHandlerLanguage(Config, args[2])
 		} else {
 			return true, errors.New("config param not found")
 		}

--- a/src/helpers/argparse.go
+++ b/src/helpers/argparse.go
@@ -18,7 +18,7 @@ import (
 // global flag structure
 type FlagStruct struct {
 	Verbose, Help, PromptExec, Tui, Output bool
-	Outfile, Prompt                        string
+	Outfile, Prompt, Language              string
 	Len                                    int
 }
 
@@ -31,7 +31,8 @@ func ConstructFlags() (Flags FlagStruct) {
 		Output:     false,
 		Outfile:    "",
 		Prompt:     "",
-		Len:        5,
+		Language:   "Bash/Unix",
+		Len:        6,
 	}
 }
 
@@ -40,13 +41,14 @@ var Usage = func() {
 	fmt.Print(`
 fl by itself will open the graphical interface. Otherwise, prompt is required.
 
-Usage: fl [-hnvt] [-o filename] prompt...
+Usage: fl [-hnvt] [-o filename] [-l language] prompt...
 
  -h,--help              show command usage
  -p                     prompt for running generated command
  -v,--verbose           display updates of the command progress
- -o                     output generated command to the passed textfile
  -t                     enter the graphical interface (TUI)
+ -o                     output generated command to the passed textfile
+ -l                     target language to generate code for, default is bash/unix commands
 
 Config: fl conf <config param>
 
@@ -85,6 +87,11 @@ func flagsHandlerOutput(Flags *FlagStruct, startPromptIndex *int, outfile string
 	*startPromptIndex += 2
 	Flags.Output = true
 	Flags.Outfile = outfile // pass name of outfile
+}
+
+func flagsHandlerLanguage(Flags *FlagStruct, startPromptIndex *int, language string) {
+	*startPromptIndex += 2
+	Flags.Language = language
 }
 
 func confHandlerAutoexec(Config *io.Config, arg string) {
@@ -164,6 +171,9 @@ func ArgParse(args []string, Flags *FlagStruct) (err error) {
 		case "-o":
 			flagsHandlerOutput(Flags, &startPromptIndex, args[i+1])
 			i++ // skip next arg (it should be filename)
+		case "-l":
+			flagsHandlerLanguage(Flags, &startPromptIndex, args[i+1])
+			i++
 		default:
 			// skip searching for switches if invalid arg is found (assume it is prompt)
 			validArg = false

--- a/src/helpers/argparse_test.go
+++ b/src/helpers/argparse_test.go
@@ -12,7 +12,8 @@ import (
 
 // test ArgParse extracts prompt with no flags
 func TestArgParseNoFlags(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl" + " " + prompt
@@ -24,7 +25,8 @@ func TestArgParseNoFlags(t *testing.T) {
 
 // one flag with no prompt
 func TestArgParseOneFlagNoPrompt(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := ""
 	cli_input := "fl -v" + " " + prompt
@@ -36,7 +38,8 @@ func TestArgParseOneFlagNoPrompt(t *testing.T) {
 
 // test ArgParse raises err when prompt is empty
 func TestArgParseEmpty(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := ""
 	cli_input := "fl" + " " + prompt
@@ -55,7 +58,8 @@ func TestArgParseEmpty(t *testing.T) {
 
 // test help
 func TestArgParseHelp(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	expectedPrompt := "" // skip prompt when -h is found
@@ -71,7 +75,8 @@ func TestArgParseHelp(t *testing.T) {
 
 // test tui
 func TestArgParseTui(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl -t" + " " + prompt
@@ -86,7 +91,8 @@ func TestArgParseTui(t *testing.T) {
 
 // test verbose
 func TestArgParseVerbose(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl -v" + " " + prompt
@@ -101,7 +107,8 @@ func TestArgParseVerbose(t *testing.T) {
 
 // test noexec
 func TestArgParsePromptExec(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl -p" + " " + prompt
@@ -116,7 +123,8 @@ func TestArgParsePromptExec(t *testing.T) {
 
 // test output
 func TestArgParseOutput(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	outfile := "outfile"
@@ -133,11 +141,30 @@ func TestArgParseOutput(t *testing.T) {
 	}
 }
 
+func TestArgParseLanguage(t *testing.T) {
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
+
+	prompt := "This is an example prompt"
+	language := "powershell"
+	cli_input := "fl -l " + language + " " + prompt
+	err := ArgParse(strings.Split(cli_input, " "), &Flags)
+	if Flags.PromptExec || Flags.Verbose || Flags.Help || Flags.Output || Flags.Tui {
+		t.Fatalf(`ArgParse("%s") should not set these flags. Actual: %+v`, cli_input, Flags)
+	}
+	if Flags.Language != language {
+		t.Fatalf(`ArgParse("%s") yields language = '%s'. Expected '%s'`, cli_input, Flags.Language, language)
+	}
+	if Flags.Prompt != prompt || err != nil {
+		t.Fatalf(`ArgParse("%s") = "%s", %v. Expected '%s'`, cli_input, Flags.Prompt, err, prompt)
+	}
+}
+
 /*
  * config opts
  */
 // test autoexec
-func TestArgParseAutoexec(t *testing.T) {
+func TestConfParseAutoexec(t *testing.T) {
 	Config := io.NewConf()
 
 	prompt := "This is an example prompt"
@@ -151,13 +178,29 @@ func TestArgParseAutoexec(t *testing.T) {
 	}
 }
 
+func TestConfParseLanguage(t *testing.T) {
+	Config := io.NewConf()
+
+	prompt := "This is an example prompt"
+	language := "powershell"
+	cli_input := "fl conf --language=" + language + " " + prompt
+	wasConfCmd, err := ConfParse(strings.Split(cli_input, " "), &Config)
+	if !wasConfCmd || err != nil {
+		t.Fatalf(`ConfParse("%s") = (%v, %v). Expected (true, nil)`, cli_input, wasConfCmd, err)
+	}
+	if Config.Language != language {
+		t.Fatalf(`ConfParse("%s") = %s. Expected '%s'`, cli_input, Config.Language, language)
+	}
+}
+
 /**********************
 * Validate multiple flag interactions
 *********************/
 
 // test help activates despite invalid prompt
 func TestArgParseHelpNoPrompt(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := ""
 	cli_input := "fl -v -h" + " " + prompt
@@ -172,7 +215,8 @@ func TestArgParseHelpNoPrompt(t *testing.T) {
 
 // test help with multiple flags, verify skip prompt parsing
 func TestArgParseHelpMultipleFlags(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	expectedPrompt := "" // skip prompt when -h is found
@@ -188,7 +232,8 @@ func TestArgParseHelpMultipleFlags(t *testing.T) {
 
 // test ArgParse with all flags + prompt
 func TestArgParseAllFlags(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	outfile := "outfile"

--- a/src/io/io.go
+++ b/src/io/io.go
@@ -35,6 +35,7 @@ const (
 
 type Config struct {
 	Autoexec bool
+	Language string
 }
 
 func (Config Config) SaveConf() (err error) {
@@ -48,6 +49,7 @@ func (Config Config) SaveConf() (err error) {
 func NewConf() Config {
 	return Config{
 		Autoexec: false,
+		Language: "Unix/Bash",
 	}
 }
 

--- a/src/web/web.go
+++ b/src/web/web.go
@@ -8,8 +8,13 @@ import (
 	"strings"
 )
 
-func PromptAI(apiUrl string, prompt string) (res *http.Response, err error) {
-	res, err = http.Post(apiUrl, "application/json", strings.NewReader(fmt.Sprintf(`{"prompt": "%s"}`, prompt)))
+func PromptAI(apiUrl string, prompt string, language string) (res *http.Response, err error) {
+	req := fmt.Sprintf(
+		`{"prompt": "%s","language": "%s"}`,
+		prompt,
+		language,
+	)
+	res, err = http.Post(apiUrl, "application/json", strings.NewReader(req))
 	return res, err
 }
 


### PR DESCRIPTION
Changed the apiurl to point to a fork of the original Flow. New flow adds an extra param to the request: `language`. See [the docs around "Initial Language Flag"](https://docs.google.com/document/d/196HX8Gj_JvBSCHZs0WeRuhqGpgiuXxcO5B1L9HEieww/edit#bookmark=id.zg59kyuw84ai) for more info.

Closes #18 