### PR TITLE
Feature explain

### DIFF
--- a/src/fl.go
+++ b/src/fl.go
@@ -38,7 +38,7 @@ func noTui(Flags helpers.FlagStruct, Config io.Config) {
 
 	// Make the API call
 	helpers.Print(Flags.Verbose, "Sending prompt...")
-	res, err := web.PromptAI(apiUrl, Flags.Prompt)
+	res, err := web.PromptAI(apiUrl, Flags.Prompt, Flags.Language)
 	if err != nil {
 		fmt.Printf("Failed to call Flows API: %s\n", err)
 		os.Exit(1)

--- a/src/fl.go
+++ b/src/fl.go
@@ -97,9 +97,6 @@ func noTui(Flags helpers.FlagStruct, Config io.Config) {
 
 func main() {
 
-	// initialize flags struct
-	Flags := helpers.ConstructFlags()
-
 	// get config data
 	Config, err := io.ReadConf()
 	if err != nil {
@@ -125,6 +122,8 @@ func main() {
 		os.Exit(0)
 	}
 
+	// initialize flags struct
+	Flags := helpers.ConstructFlags(Config)
 	// parse arguments and recieve prompt
 	err = helpers.ArgParse(os.Args, &Flags)
 

--- a/src/fl.go
+++ b/src/fl.go
@@ -58,7 +58,21 @@ func noTui(Flags helpers.FlagStruct, Config io.Config) {
 	fmt.Println(result)
 	fmt.Println()
 
+	// copy to clipboard
 	clipboard.Write(clipboard.FmtText, []byte(result))
+
+	// check if explain flag, then look
+	if Flags.Explain {
+		helpers.Print(Flags.Verbose, "Sending command for explanation...")
+
+		explanation, err := web.ExplainCommand(result, Flags.Language)
+		if err != nil {
+			fmt.Printf("Failed to call Flows API: %s\n", err)
+			os.Exit(1)
+		}
+
+		fmt.Println(explanation)
+	}
 
 	// if not skipping prompt, ask user if they would like to execute
 	userExecute := false

--- a/src/fl.go
+++ b/src/fl.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	// url of the Flow endpoint
-	apiUrl = "https://flow.pstmn-beta.io/api/4e5b4cfcdec54831a31d9f38aaf1a938"
+	apiUrl = "https://flow.pstmn-beta.io/api/38a029541f794a65afb284a7f4e7d3b3"
 )
 
 func init() {

--- a/src/helpers/argparse.go
+++ b/src/helpers/argparse.go
@@ -22,7 +22,7 @@ type FlagStruct struct {
 	Len                                    int
 }
 
-func ConstructFlags() (Flags FlagStruct) {
+func ConstructFlags(Config io.Config) (Flags FlagStruct) {
 	return FlagStruct{
 		Verbose:    false,
 		Help:       false,
@@ -31,7 +31,7 @@ func ConstructFlags() (Flags FlagStruct) {
 		Output:     false,
 		Outfile:    "",
 		Prompt:     "",
-		Language:   "Bash/Unix",
+		Language:   Config.Language,
 		Len:        6,
 	}
 }
@@ -53,6 +53,7 @@ Usage: fl [-hnvt] [-o filename] [-l language] prompt...
 Config: fl conf <config param>
 
  --autoexecute=BOOL     enable autoexecution
+ --language=STRING      change the DEFAULT language/environment to generate a command for
 
 `)
 }
@@ -104,6 +105,12 @@ func confHandlerAutoexec(Config *io.Config, arg string) {
 	}
 }
 
+func confHandlerLanguage(Config *io.Config, arg string) {
+	// rewrite autoexec with right side of '='
+	value := strings.Split(arg, "=")[1]
+	Config.Language = strings.ToLower(value)
+}
+
 /**********************
  * Other parse helpers
  *********************/
@@ -118,6 +125,7 @@ func IsEmpty(str string) bool {
 
 var (
 	regex_autoexecute = regexp.MustCompile("--autoexecute=")
+	regex_language    = regexp.MustCompile("--language=")
 )
 
 // check if this is a config command - follow format 'fl config <CONFIGCMD>'
@@ -125,6 +133,8 @@ func ConfParse(args []string, Config *io.Config) (confCmd bool, err error) {
 	if args[1] == "conf" {
 		if regex_autoexecute.MatchString(args[2]) {
 			confHandlerAutoexec(Config, args[2])
+		} else if regex_language.MatchString(args[2]) {
+			confHandlerLanguage(Config, args[2])
 		} else {
 			return true, errors.New("config param not found")
 		}

--- a/src/helpers/argparse.go
+++ b/src/helpers/argparse.go
@@ -17,9 +17,9 @@ import (
 
 // global flag structure
 type FlagStruct struct {
-	Verbose, Help, PromptExec, Tui, Output bool
-	Outfile, Prompt, Language              string
-	Len                                    int
+	Verbose, Help, PromptExec, Tui, Output, Explain bool
+	Outfile, Prompt, Language                       string
+	Len                                             int
 }
 
 func ConstructFlags(Config io.Config) (Flags FlagStruct) {
@@ -29,10 +29,11 @@ func ConstructFlags(Config io.Config) (Flags FlagStruct) {
 		PromptExec: false,
 		Tui:        false,
 		Output:     false,
+		Explain:    false,
 		Outfile:    "",
 		Prompt:     "",
 		Language:   Config.Language,
-		Len:        6,
+		Len:        7,
 	}
 }
 
@@ -47,8 +48,9 @@ Usage: fl [-hnvt] [-o filename] [-l language] prompt...
  -p                     prompt for running generated command
  -v,--verbose           display updates of the command progress
  -t                     enter the graphical interface (TUI)
- -o                     output generated command to the passed textfile
  -l                     target language to generate code for, default is bash/unix commands
+ -e                     for extra verification, ask AI what the generated command does
+ -o                     output generated command to the passed textfile
 
 Config: fl conf <config param>
 
@@ -82,6 +84,11 @@ func flagsHandlerVerbose(Flags *FlagStruct, startPromptIndex *int) {
 func flagsHandlerPrompt(Flags *FlagStruct, startPromptIndex *int) {
 	*startPromptIndex++
 	Flags.PromptExec = true
+}
+
+func flagsHandlerExplain(Flags *FlagStruct, startPromptIndex *int) {
+	*startPromptIndex++
+	Flags.Explain = true
 }
 
 func flagsHandlerOutput(Flags *FlagStruct, startPromptIndex *int, outfile string) {
@@ -178,6 +185,8 @@ func ArgParse(args []string, Flags *FlagStruct) (err error) {
 			flagsHandlerVerbose(Flags, &startPromptIndex)
 		case "-p":
 			flagsHandlerPrompt(Flags, &startPromptIndex)
+		case "-e":
+			flagsHandlerExplain(Flags, &startPromptIndex)
 		case "-o":
 			flagsHandlerOutput(Flags, &startPromptIndex, args[i+1])
 			i++ // skip next arg (it should be filename)

--- a/src/helpers/argparse.go
+++ b/src/helpers/argparse.go
@@ -48,9 +48,10 @@ Usage: fl [-hnvt] [-o filename] [-l language] prompt...
  -p                     prompt for running generated command
  -v,--verbose           display updates of the command progress
  -t                     enter the graphical interface (TUI)
- -l                     target language to generate code for, default is bash/unix commands
  -e                     for extra verification, ask AI what the generated command does
- -o                     output generated command to the passed textfile
+ -o outfile             output generated command to the passed textfile
+ -l language            target language to generate code for, default is bash/unix commands
+                        ┃ target language can also be a desired command name!
 
 Config: fl conf <config param>
 

--- a/src/helpers/argparse.go
+++ b/src/helpers/argparse.go
@@ -18,7 +18,7 @@ import (
 // global flag structure
 type FlagStruct struct {
 	Verbose, Help, PromptExec, Tui, Output bool
-	Outfile, Prompt                        string
+	Outfile, Prompt, Language              string
 	Len                                    int
 }
 
@@ -31,7 +31,8 @@ func ConstructFlags() (Flags FlagStruct) {
 		Output:     false,
 		Outfile:    "",
 		Prompt:     "",
-		Len:        5,
+		Language:   "Bash/Unix",
+		Len:        6,
 	}
 }
 
@@ -40,13 +41,14 @@ var Usage = func() {
 	fmt.Print(`
 fl by itself will open the graphical interface. Otherwise, prompt is required.
 
-Usage: fl [-hnvt] [-o filename] prompt...
+Usage: fl [-hnvt] [-o filename] [-l language] prompt...
 
  -h,--help              show command usage
  -p                     prompt for running generated command
  -v,--verbose           display updates of the command progress
- -o                     output generated command to the passed textfile
  -t                     enter the graphical interface (TUI)
+ -o                     output generated command to the passed textfile
+ -l                     target language to generate code for, default is bash/unix commands
 
 Config: fl conf <config param>
 
@@ -85,6 +87,11 @@ func flagsHandlerOutput(Flags *FlagStruct, startPromptIndex *int, outfile string
 	*startPromptIndex += 2
 	Flags.Output = true
 	Flags.Outfile = outfile // pass name of outfile
+}
+
+func flagsHandlerLanguage(Flags *FlagStruct, startPromptIndex *int, language string) {
+	*startPromptIndex += 2
+	Flags.Language = language
 }
 
 func confHandlerAutoexec(Config *io.Config, arg string) {
@@ -164,6 +171,9 @@ func ArgParse(args []string, Flags *FlagStruct) (err error) {
 		case "-o":
 			flagsHandlerOutput(Flags, &startPromptIndex, args[i+1])
 			i++ // skip next arg (it should be filename)
+		case "-l":
+			flagsHandlerLanguage(Flags, &startPromptIndex, args[i+1])
+			i++
 		default:
 			// skip searching for switches if invalid arg is found (assume it is prompt)
 			validArg = false

--- a/src/helpers/argparse_test.go
+++ b/src/helpers/argparse_test.go
@@ -12,7 +12,8 @@ import (
 
 // test ArgParse extracts prompt with no flags
 func TestArgParseNoFlags(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl" + " " + prompt
@@ -24,7 +25,8 @@ func TestArgParseNoFlags(t *testing.T) {
 
 // one flag with no prompt
 func TestArgParseOneFlagNoPrompt(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := ""
 	cli_input := "fl -v" + " " + prompt
@@ -36,7 +38,8 @@ func TestArgParseOneFlagNoPrompt(t *testing.T) {
 
 // test ArgParse raises err when prompt is empty
 func TestArgParseEmpty(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := ""
 	cli_input := "fl" + " " + prompt
@@ -55,7 +58,8 @@ func TestArgParseEmpty(t *testing.T) {
 
 // test help
 func TestArgParseHelp(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	expectedPrompt := "" // skip prompt when -h is found
@@ -71,7 +75,8 @@ func TestArgParseHelp(t *testing.T) {
 
 // test tui
 func TestArgParseTui(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl -t" + " " + prompt
@@ -86,7 +91,8 @@ func TestArgParseTui(t *testing.T) {
 
 // test verbose
 func TestArgParseVerbose(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl -v" + " " + prompt
@@ -101,7 +107,8 @@ func TestArgParseVerbose(t *testing.T) {
 
 // test noexec
 func TestArgParsePromptExec(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	cli_input := "fl -p" + " " + prompt
@@ -116,7 +123,8 @@ func TestArgParsePromptExec(t *testing.T) {
 
 // test output
 func TestArgParseOutput(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	outfile := "outfile"
@@ -133,11 +141,30 @@ func TestArgParseOutput(t *testing.T) {
 	}
 }
 
+func TestArgParseLanguage(t *testing.T) {
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
+
+	prompt := "This is an example prompt"
+	language := "powershell"
+	cli_input := "fl -l " + language + " " + prompt
+	err := ArgParse(strings.Split(cli_input, " "), &Flags)
+	if Flags.PromptExec || Flags.Verbose || Flags.Help || Flags.Output || Flags.Tui {
+		t.Fatalf(`ArgParse("%s") should not set these flags. Actual: %+v`, cli_input, Flags)
+	}
+	if Flags.Language != language {
+		t.Fatalf(`ArgParse("%s") yields language = '%s'. Expected '%s'`, cli_input, Flags.Language, language)
+	}
+	if Flags.Prompt != prompt || err != nil {
+		t.Fatalf(`ArgParse("%s") = "%s", %v. Expected '%s'`, cli_input, Flags.Prompt, err, prompt)
+	}
+}
+
 /*
  * config opts
  */
 // test autoexec
-func TestArgParseAutoexec(t *testing.T) {
+func TestConfParseAutoexec(t *testing.T) {
 	Config := io.NewConf()
 
 	prompt := "This is an example prompt"
@@ -151,13 +178,29 @@ func TestArgParseAutoexec(t *testing.T) {
 	}
 }
 
+func TestConfParseLanguage(t *testing.T) {
+	Config := io.NewConf()
+
+	prompt := "This is an example prompt"
+	language := "powershell"
+	cli_input := "fl conf --language=" + language + " " + prompt
+	wasConfCmd, err := ConfParse(strings.Split(cli_input, " "), &Config)
+	if !wasConfCmd || err != nil {
+		t.Fatalf(`ConfParse("%s") = (%v, %v). Expected (true, nil)`, cli_input, wasConfCmd, err)
+	}
+	if Config.Language != language {
+		t.Fatalf(`ConfParse("%s") = %s. Expected '%s'`, cli_input, Config.Language, language)
+	}
+}
+
 /**********************
 * Validate multiple flag interactions
 *********************/
 
 // test help activates despite invalid prompt
 func TestArgParseHelpNoPrompt(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := ""
 	cli_input := "fl -v -h" + " " + prompt
@@ -172,7 +215,8 @@ func TestArgParseHelpNoPrompt(t *testing.T) {
 
 // test help with multiple flags, verify skip prompt parsing
 func TestArgParseHelpMultipleFlags(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	expectedPrompt := "" // skip prompt when -h is found
@@ -188,7 +232,8 @@ func TestArgParseHelpMultipleFlags(t *testing.T) {
 
 // test ArgParse with all flags + prompt
 func TestArgParseAllFlags(t *testing.T) {
-	Flags := ConstructFlags()
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
 
 	prompt := "This is an example prompt"
 	outfile := "outfile"

--- a/src/helpers/argparse_test.go
+++ b/src/helpers/argparse_test.go
@@ -121,6 +121,21 @@ func TestArgParsePromptExec(t *testing.T) {
 	}
 }
 
+func TestArgParseExplain(t *testing.T) {
+	Config := io.NewConf()
+	Flags := ConstructFlags(Config)
+
+	prompt := "This is an example prompt"
+	cli_input := "fl -e" + " " + prompt
+	err := ArgParse(strings.Split(cli_input, " "), &Flags)
+	if Flags.PromptExec || Flags.Verbose || Flags.Help || Flags.Output || Flags.Tui || !Flags.Explain {
+		t.Fatalf(`ArgParse("%s") expects only the %s flag. Actual: %+v`, cli_input, "n", Flags)
+	}
+	if Flags.Prompt != prompt || err != nil {
+		t.Fatalf(`ArgParse("%s") = "%s", %v. Expected '%s'`, cli_input, Flags.Prompt, err, prompt)
+	}
+}
+
 // test output
 func TestArgParseOutput(t *testing.T) {
 	Config := io.NewConf()

--- a/src/io/io.go
+++ b/src/io/io.go
@@ -35,6 +35,7 @@ const (
 
 type Config struct {
 	Autoexec bool
+	Language string
 }
 
 func (Config Config) SaveConf() (err error) {
@@ -48,6 +49,7 @@ func (Config Config) SaveConf() (err error) {
 func NewConf() Config {
 	return Config{
 		Autoexec: false,
+		Language: "Unix/Bash",
 	}
 }
 

--- a/src/web/web.go
+++ b/src/web/web.go
@@ -8,8 +8,13 @@ import (
 	"strings"
 )
 
-func PromptAI(apiUrl string, prompt string) (res *http.Response, err error) {
-	res, err = http.Post(apiUrl, "application/json", strings.NewReader(fmt.Sprintf(`{"prompt": "%s"}`, prompt)))
+func PromptAI(apiUrl string, prompt string, language string) (res *http.Response, err error) {
+	req := fmt.Sprintf(
+		`{"prompt": "%s","language": "%s"}`,
+		prompt,
+		language,
+	)
+	res, err = http.Post(apiUrl, "application/json", strings.NewReader(req))
 	return res, err
 }
 

--- a/src/web/web.go
+++ b/src/web/web.go
@@ -4,9 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
-	"strings"
 )
 
 const (
@@ -43,12 +41,13 @@ func ExplainCommand(command string, language string) (result string, err error) 
 }
 
 func PromptAI(apiUrl string, prompt string, language string) (res *http.Response, err error) {
-	req := fmt.Sprintf(
-		`{"prompt": "%s","language": "%s"}`,
-		prompt,
-		language,
-	)
-	res, err = http.Post(apiUrl, "application/json", strings.NewReader(req))
+	// convert to JSON for proper escaping of strings which may be in the command
+	req := map[string]string{
+		"prompt":   prompt,
+		"language": language,
+	}
+	reqJSON, _ := json.Marshal(req)
+	res, err = http.Post(apiUrl, "application/json", bytes.NewBuffer(reqJSON))
 	return res, err
 }
 

--- a/src/web/web.go
+++ b/src/web/web.go
@@ -1,12 +1,46 @@
 package web
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 )
+
+const (
+	explainUrl = "https://flow.pstmn-beta.io/api/30292fd2914e417a8b2d61e76b73edeb"
+)
+
+func ExplainCommand(command string, language string) (result string, err error) {
+	var data map[string]interface{}
+
+	// convert to JSON for proper escaping of strings which may be in the command
+	req := map[string]string{
+		"command":  command,
+		"language": language,
+	}
+	reqJSON, _ := json.Marshal(req)
+	response, err := http.Post(explainUrl, "application/json", bytes.NewBuffer(reqJSON))
+
+	if err != nil {
+		return "Failed to send response", err
+	}
+	defer response.Body.Close()
+
+	err = json.NewDecoder(response.Body).Decode(&data)
+	if err != nil {
+		return "Failed to parse Flows API response: %s\n", err
+	}
+
+	result, ok := data["output"].(string)
+	if !ok {
+		return "", errors.New("expected output field not found in Flows API response")
+	}
+
+	return result, nil
+}
 
 func PromptAI(apiUrl string, prompt string, language string) (res *http.Response, err error) {
 	req := fmt.Sprintf(


### PR DESCRIPTION
This PR branches depends on changes made to #19, so please look at that one first!

Add -e, which sends a request to a new Flow whose purpose is to take a command and return an explanation. This helps with user confidence, as they can doublecheck that their prompt was not misunderstood. With prompt engineering (this is separate from the code), we can make the explanation more useful:

- "What do the included flags mean?"
- "If this code is invalid, can you explain why?"

Here's some examples of the workflow with UX with and without `-l` as well:

`fl -e send a request to example.com with the following key value pairs in JSON format: command="ls -al", language=bash`
```
curl -X POST -d '{"command":"ls -al", "language":"bash"}' -H "Content-Type: application/json" https://example.com

This command sends a POST request to https://example.com with a JSON payload containing the keys "command" and "language". The value of "command" is "ls -al" and the value of "language" is "bash".
```

`fl -l wget -e send a request to example.com with the following key value pairs in JSON format: command="ls -al", language=bash`
```
wget --header="Content-Type: application/json" --post-data='{"command":"ls -al","language":"bash"}' http://example.com

This wget command sends a POST request to http://example.com with a JSON payload containing a command and language. The command is "ls -al" in the bash language. It also includes a header specifying the content type as application/json.
```

`fl -l powershell -e send a request to example.com with the following key value pairs in JSON format: command="ls -al", language=bash`
```
Invoke-RestMethod -Uri "http://example.com" -Method POST -Body (@{command="ls -al"; language="bash"} | ConvertTo-Json) -ContentType "application/json"

This PowerShell code sends a POST request to "http://example.com" with a JSON body containing a command and a language. The command is "ls -al" and the language is "bash". The request is made using the Invoke-RestMethod cmdlet with the specified URI, method, JSON body, and content type.
```

Closes #10 